### PR TITLE
Add tests for all /auth controllers #22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ node_modules/
 .env.development.local
 .env.test.local
 .env.production.local
-
+sample.env
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/README.md
+++ b/README.md
@@ -16,25 +16,25 @@ This is a little description about your project.
 
 ## Server
 
-1. Go into the server directory `cd server`
-2. Run `npm install` to install packages
+1. Go into the server directory ```cd server```
+2. Run ```npm install``` to install packages
 3. Create your environment variable (.env) file
-4. Run `npm run dev` to start the server
+4. Run ```npm run dev``` to start the server
 
 ---
 
 ## Client
 
-1. Go into the client directory `cd client`
-2. Run `npm install` to install packages
-3. Run `npm start` to start the client side
+1. Go into the client directory ```cd client```
+2. Run ```npm install``` to install packages
+3. Run ```npm start``` to start the client side
 
 ---
 
 ## Test
 
-1. Go into the server directory `cd server`
-2. Run `npm test` to run tests
+1. Go into the server directory ```cd server```
+2. Run ```npm test``` to run tests
 ---
 
 ### Demo

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ This is a little description about your project.
 
 ---
 
+## Test
+
+1. Go into the server directory `cd server`
+2. Run `npm test` to run tests
+---
+
 ### Demo
 
 1. Registration. Users will be able to create a new account using their email and password

--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -114,3 +114,10 @@ exports.logoutUser = asyncHandler(async (req, res, next) => {
 
   res.send("You have successfully logged out");
 });
+
+// @route POST /auth/logout
+// @desc Ping test with logout controller
+// @access Public
+exports.pingLogout = asyncHandler(async (req, res, next) => {
+  res.send(`Server is running. Message received: ${req.body.message}`);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "nodemon --exec 'mocha test/*.js'",
     "dev": "nodemon ./bin/www"
   },
   "dependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -27,7 +27,8 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "chai-http": "^4.3.0",
-    "mocha": "^8.2.1"
+    "mocha": "^8.2.1",
+    "sinon": "^11.1.2"
   },
   "author": "",
   "license": "ISC"

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,23 +1,23 @@
-const express = require('express');
+const express = require("express");
 const router = express.Router();
-const { validateRegister, validateLogin } = require('../validate');
-const protect = require('../middleware/auth');
+const { validateRegister, validateLogin } = require("../validate");
+const protect = require("../middleware/auth");
 const {
   registerUser,
   loginUser,
   loadUser,
   logoutUser,
   pingLogout
-} = require('../controllers/auth');
+} = require("../controllers/auth");
 
-router.route('/register').post(validateRegister, registerUser);
+router.route("/register").post(validateRegister, registerUser);
 
-router.route('/login').post(validateLogin, loginUser);
+router.route("/login").post(validateLogin, loginUser);
 
-router.route('/user').get(protect, loadUser);
+router.route("/user").get(protect, loadUser);
 
-router.route('/logout').get(logoutUser);
+router.route("/logout").get(logoutUser);
 
-router.route('/logout').post(pingLogout);
+router.route("/logout").post(pingLogout);
 
 module.exports = router;

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -7,6 +7,7 @@ const {
   loginUser,
   loadUser,
   logoutUser,
+  pingLogout
 } = require('../controllers/auth');
 
 router.route('/register').post(validateRegister, registerUser);
@@ -16,5 +17,7 @@ router.route('/login').post(validateLogin, loginUser);
 router.route('/user').get(protect, loadUser);
 
 router.route('/logout').get(logoutUser);
+
+router.route('/logout').post(pingLogout);
 
 module.exports = router;

--- a/server/test/auth.spec.js
+++ b/server/test/auth.spec.js
@@ -108,7 +108,7 @@ describe("Tests for all /auth controllers", () => {
     it("should not be able to register if email already exists", async () => {
       const res = await agent.post("/auth/register").send({
         username: testNewUserInfo.username,
-        email: testUserInfo.email,
+        email: createdTestUser.email,
         password: testNewUserInfo.password
       });
       res.should.have.status(400);

--- a/server/test/auth.spec.js
+++ b/server/test/auth.spec.js
@@ -14,6 +14,7 @@ let clock;
 const existingUser = {
   username: "test",
   email: "test@gmail.com",
+  invalidEmail: "testgmail.com",
   password: "123123",
   wrongPassword: "wrongPassword"
 };
@@ -42,7 +43,7 @@ describe("Tests for all /auth controllers", () => {
       agent.should.have.cookie("token");
     });
 
-    it("should not be able to login with invalid email", async () => {
+    it("should not be able to login with nonExisting email", async () => {
       const res = await agent
         .post("/auth/login")
         .send({ email: nonExistingUser.email, password: existingUser.password });
@@ -57,6 +58,29 @@ describe("Tests for all /auth controllers", () => {
         .send({ email: existingUser.email, password: existingUser.wrongPassword });
       res.should.have.status(401);
       res.should.have.property("text").contains("Invalid email or password");
+      agent.should.not.have.cookie("token");
+    });
+
+    it("should not be able to login if email field is missing", async () => {
+      const res = await agent.post("/auth/login").send({ password: nonExistingUser.password });
+      res.should.have.status(400);
+      res.should.have.property("text").contains("Please enter a valid email address");
+      agent.should.not.have.cookie("token");
+    });
+
+    it("should not be able to login if email is invalid", async () => {
+      const res = await agent
+        .post("/auth/login")
+        .send({ email: existingUser.invalidEmail, password: nonExistingUser.password });
+      res.should.have.status(400);
+      res.should.have.property("text").contains("Please enter a valid email address");
+      agent.should.not.have.cookie("token");
+    });
+
+    it("should not be able to login if password field is missing", async () => {
+      const res = await agent.post("/auth/login").send({ email: existingUser.email });
+      res.should.have.status(400);
+      res.should.have.property("text").contains("Password is required");
       agent.should.not.have.cookie("token");
     });
   });

--- a/server/test/auth.spec.js
+++ b/server/test/auth.spec.js
@@ -1,0 +1,200 @@
+require("dotenv").config({ path: __dirname + "/../sample.env" });
+const chai = require("chai");
+const chaiHttp = require("chai-http");
+const sinon = require("sinon");
+const { app } = require("../app.js");
+const User = require("../models/User");
+
+chai.should();
+chai.use(chaiHttp);
+
+let agent;
+let clock;
+
+const existingUser = {
+  username: "test",
+  email: "test@gmail.com",
+  password: "123123",
+  wrongPassword: "wrongPassword"
+};
+
+const nonExistingUser = {
+  username: "newUser",
+  email: "notRegistered@gmail.com",
+  invalidEmail: "notRegisteredgmail.com",
+  password: "randomPassword",
+  shortPassword: "1234"
+};
+
+describe("Tests for all /auth controllers", () => {
+  beforeEach(() => {
+    agent = chai.request.agent(app);
+  });
+
+  describe("Tests for /auth/login", () => {
+    it("should be able to login with valid credentials", async () => {
+      const res = await agent
+        .post("/auth/login")
+        .send({ email: existingUser.email, password: existingUser.password });
+      res.should.have.status(200);
+      res.should.have.property("text").contains(existingUser.username);
+      res.should.have.property("text").contains(existingUser.email);
+      agent.should.have.cookie("token");
+    });
+
+    it("should not be able to login with invalid email", async () => {
+      const res = await agent
+        .post("/auth/login")
+        .send({ email: nonExistingUser.email, password: existingUser.password });
+      res.should.have.status(401);
+      res.should.have.property("text").contains("Invalid email or password");
+      agent.should.not.have.cookie("token");
+    });
+
+    it("should not be able to login with invalid password", async () => {
+      const res = await agent
+        .post("/auth/login")
+        .send({ email: existingUser.email, password: existingUser.wrongPassword });
+      res.should.have.status(401);
+      res.should.have.property("text").contains("Invalid email or password");
+      agent.should.not.have.cookie("token");
+    });
+  });
+
+  describe("Tests for /auth/register", () => {
+    it("should be able to register", async () => {
+      const res = await agent.post("/auth/register").send({
+        username: nonExistingUser.username,
+        email: nonExistingUser.email,
+        password: nonExistingUser.password
+      });
+      res.should.have.status(201);
+      res.should.have.property("text").contains(nonExistingUser.username);
+      res.should.have.property("text").contains(nonExistingUser.email);
+      agent.should.have.cookie("token");
+      await User.findOneAndDelete({ email: nonExistingUser.email });
+    });
+
+    it("should not be able to register if email already exists", async () => {
+      const res = await agent.post("/auth/register").send({
+        username: nonExistingUser.username,
+        email: existingUser.email,
+        password: nonExistingUser.password
+      });
+      res.should.have.status(400);
+      res.should.have.property("text").contains("A user with that email already exists");
+      agent.should.not.have.cookie("token");
+    });
+
+    it("should not be able to register if username already exists", async () => {
+      const res = await agent.post("/auth/register").send({
+        username: existingUser.username,
+        email: nonExistingUser.email,
+        password: nonExistingUser.password
+      });
+      res.should.have.status(400);
+      res.should.have.property("text").contains("A user with that username already exists");
+      agent.should.not.have.cookie("token");
+    });
+
+    it("should not be able to register if username field is missing", async () => {
+      const res = await agent
+        .post("/auth/register")
+        .send({ email: nonExistingUser.email, password: nonExistingUser.password });
+      res.should.have.status(400);
+      res.should.have.property("text").contains("Please enter a username");
+      agent.should.not.have.cookie("token");
+    });
+
+    it("should not be able to register if email field is missing", async () => {
+      const res = await agent
+        .post("/auth/register")
+        .send({ username: nonExistingUser.username, password: nonExistingUser.password });
+      res.should.have.status(400);
+      res.should.have.property("text").contains("Please enter a valid email address");
+      agent.should.not.have.cookie("token");
+    });
+
+    it("should not be able to register if password field is missing", async () => {
+      const res = await agent
+        .post("/auth/register")
+        .send({ username: nonExistingUser.username, email: nonExistingUser.email });
+      res.should.have.status(400);
+      res.should.have
+        .property("text")
+        .contains("Please enter a password with 6 or more characters");
+      agent.should.not.have.cookie("token");
+    });
+
+    it("should not be able to register if email is invalid", async () => {
+      const res = await agent.post("/auth/register").send({
+        username: nonExistingUser.username,
+        email: nonExistingUser.invalidEmail,
+        password: nonExistingUser.password
+      });
+      res.should.have.status(400);
+      res.should.have.property("text").contains("Please enter a valid email address");
+      agent.should.not.have.cookie("token");
+    });
+
+    it("should not be able to register if length of password is less than 6 characters", async () => {
+      const res = await agent.post("/auth/register").send({
+        username: nonExistingUser.username,
+        email: nonExistingUser.email,
+        password: nonExistingUser.shortPassword
+      });
+      res.should.have.status(400);
+      res.should.have
+        .property("text")
+        .contains("Please enter a password with 6 or more characters");
+      agent.should.not.have.cookie("token");
+    });
+  });
+
+  describe("Tests for /auth/user", () => {
+    it("should be able to get user data with authorization", async () => {
+      await agent
+        .post("/auth/login")
+        .send({ email: existingUser.email, password: existingUser.password });
+      const res = await agent.get("/auth/user");
+      res.should.have.status(200);
+      res.should.have.property("text").contains(existingUser.username);
+      res.should.have.property("text").contains(existingUser.email);
+      agent.should.have.cookie("token");
+    });
+
+    it("should not be able to get user data without authorization", async () => {
+      const res = await agent.get("/auth/user");
+      res.should.have.status(401);
+      res.should.have.property("text").contains("No token, authorization denied");
+      agent.should.not.have.cookie("token");
+    });
+
+    it("should not be able to get user data with expired token", async () => {
+      clock = sinon.useFakeTimers();
+      await agent
+        .post("/auth/login")
+        .send({ email: existingUser.email, password: existingUser.password });
+      const secondsInWeek = 604800;
+      clock.tick(secondsInWeek * 1000);
+      const res = await agent.get("/auth/user");
+      res.should.have.status(401);
+      res.should.have.property("text").contains("No token, authorization denied");
+      agent.should.not.have.cookie("token");
+      clock.restore();
+    });
+  });
+
+  describe("Tests for /auth/logout", () => {
+    it("should be able to logout", async () => {
+      const res = await agent.get("/auth/logout");
+      res.should.have.status(200);
+      res.should.have.property("text").contains("You have successfully logged out");
+      agent.should.not.have.cookie("token");
+    });
+  });
+
+  afterEach(() => {
+    agent.close();
+  });
+});

--- a/server/test/ping.spec.js
+++ b/server/test/ping.spec.js
@@ -1,22 +1,16 @@
+require("dotenv").config({path:__dirname + '/../sample.env'});
 const chai = require("chai");
 const chaiHttp = require("chai-http");
-const app = require("../app.js");
+const { app } = require("../app.js");
 
 chai.should();
 chai.use(chaiHttp);
 
-describe("/POST ping", () => {
-  it("it should return 200 and message", (done) => {
-    chai
-      .request(app)
-      .post(`/ping/`)
-      .send({ message: "hello" })
-      .end((err, res) => {
-        res.should.have.status(200);
-        res.body.should.have
-          .property("response")
-          .eql("Server is running. Message received: hello");
-        done();
-      });
-  });
+describe("Ping test with logout controller", () => {  
+  it('should return 200 and message', async () => {
+    const testingMessage = { message: 'Ping test with logout controller' }
+    const res = await chai.request.agent(app).post('/auth/logout').send(testingMessage)
+    res.should.have.status(200);
+    res.should.have.property('text').eql(`Server is running. Message received: ${testingMessage.message}`);
+  })
 });

--- a/server/test/ping.spec.js
+++ b/server/test/ping.spec.js
@@ -1,4 +1,4 @@
-require("dotenv").config({path:__dirname + '/../sample.env'});
+require("dotenv").config({ path: __dirname + "/../sample.env" });
 const chai = require("chai");
 const chaiHttp = require("chai-http");
 const { app } = require("../app.js");
@@ -6,11 +6,13 @@ const { app } = require("../app.js");
 chai.should();
 chai.use(chaiHttp);
 
-describe("Ping test with logout controller", () => {  
-  it('should return 200 and message', async () => {
-    const testingMessage = { message: 'Ping test with logout controller' }
-    const res = await chai.request.agent(app).post('/auth/logout').send(testingMessage)
+describe("Ping test with logout controller", () => {
+  it("should return 200 and message", async () => {
+    const testingMessage = { message: "Ping test with logout controller" };
+    const res = await chai.request.agent(app).post("/auth/logout").send(testingMessage);
     res.should.have.status(200);
-    res.should.have.property('text').eql(`Server is running. Message received: ${testingMessage.message}`);
-  })
+    res.should.have
+      .property("text")
+      .eql(`Server is running. Message received: ${testingMessage.message}`);
+  });
 });

--- a/server/validate.js
+++ b/server/validate.js
@@ -11,8 +11,6 @@ exports.validateRegister = [
   }),
   (req, res, next) => {
     const errors = validationResult(req);
-
-    console.log(errors);
     if (!errors.isEmpty())
       return res.status(400).json({ errors: errors.array() });
     next();


### PR DESCRIPTION
### What this PR does (required):
- Issue Link: https://github.com/hatchways/team-breadsticks/issues/22
- Added tests for all /auth controllers (```/register```, ```/user```, ```/login```, and ```/logout```)

### Screenshots / Videos (required):
![Screen Shot 2021-09-16 at 14 39 38](https://user-images.githubusercontent.com/54833010/133689394-05792b55-6db8-4919-be31-a25cfbb29154.png)

### Any information needed to test this feature (required):
- Go into the server directory ```cd server```
- Run ```npm test``` to run tests

### Any issues with the current functionality (optional):
- N/A
