### PR TITLE
FE: Profile Listings page #41

### DIFF
--- a/client/src/pages/Layout/useStyles.ts
+++ b/client/src/pages/Layout/useStyles.ts
@@ -23,7 +23,6 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: '#eee',
   },
 }));
 

--- a/client/src/pages/Listings/Listings.tsx
+++ b/client/src/pages/Listings/Listings.tsx
@@ -1,4 +1,4 @@
-import { useState, ChangeEvent } from 'react';
+import { useState, SyntheticEvent } from 'react';
 import Box from '@material-ui/core/Box';
 import Grid from '@mui/material/Grid';
 import Button from '@material-ui/core/Button';
@@ -18,7 +18,7 @@ const Listings = (): JSX.Element => {
   const [newSitter, setNewSitter] = useState<Sitter | null>(null);
   const classes = useStyles();
 
-  const searchLocationHandleChange = (e: ChangeEvent<HTMLInputElement>, newInputValue: string) => {
+  const searchLocationHandleChange = (e: SyntheticEvent<Element, Event>, newInputValue: string) => {
     setSearch(newInputValue);
     if (newSitter) {
       setNewSitter(null);
@@ -51,7 +51,7 @@ const Listings = (): JSX.Element => {
           <SearchDateRange dateRange={dateRange} handleChange={searchDateRangeHandleChange} />
         </Box>
 
-        <Grid container className={classes.sitterLists} justifyContent="center">
+        <Grid container className={classes.sitterLists} justifyContent="space-evenly">
           {sampleData.slice(0, 6).map((sitter) => (
             <SitterCard key={sitter.sitterId} sitter={sitter} />
           ))}

--- a/client/src/pages/Listings/Listings.tsx
+++ b/client/src/pages/Listings/Listings.tsx
@@ -1,39 +1,68 @@
+import { useState, ChangeEvent } from 'react';
 import Box from '@material-ui/core/Box';
 import Grid from '@material-ui/core/Grid';
+import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
-import { Link } from 'react-router-dom';
+import { DateRange } from '@mui/lab/DateRangePicker';
 import Layout from '../Layout/Layout';
+import { Sitter } from '../../pages/Profile/ProfileDetail/sampleData';
+import SearchLocation from './SearchLocation/SearchLocation';
+import SearchDateRange from './SearchDateRange/SearchDateRange';
+import SitterCard from './SitterCard/SitterCard';
+import { sampleData } from '../Profile/ProfileDetail/sampleData';
 import useStyles from './useStyles';
 
 const Listings = (): JSX.Element => {
-  // TODO: this will be used in the future
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [dateRange, setDateRange] = useState<DateRange<Date | null>>([null, null]);
+  const [search, setSearch] = useState<string>('test');
+  const [newSitter, setNewSitter] = useState<Sitter | null>(null);
   const classes = useStyles();
+
+  const searchLocationHandleChange = (e: ChangeEvent<HTMLInputElement>, newInputValue: string) => {
+    setSearch(newInputValue);
+    if (newSitter) {
+      setNewSitter(null);
+    }
+  };
+
+  const searchDateRangeHandleChange = (newDateRange: DateRange<Date>) => {
+    setDateRange(newDateRange);
+  };
+
+  // TODO: implement this feature later in the future
+  const handleShowMore = () => {
+    console.log('Load More clicked');
+  };
 
   return (
     <Layout>
-      <Grid>
-        <Box height="50px" display="flex" justifyContent="center" alignItems="center">
-          <Typography component="h5" variant="h5" align="center">
-            Temporary Listings Page
+      <Grid className={classes.listings}>
+        <Box
+          height="50px"
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          className={classes.searchTitleBox}
+        >
+          <Typography component="h4" variant="h4" align="center" className={classes.searchTitleText}>
+            Your search results
           </Typography>
         </Box>
-        <Box height="50px" display="flex" justifyContent="center" alignItems="center">
-          <Typography component="h5" variant="h5" align="center">
-            ProfileDetails will be displayed here
-          </Typography>
+        <Box display="flex" justifyContent="center" alignItems="center" className={classes.searchBox}>
+          <SearchLocation search={search} handleChange={searchLocationHandleChange} />
+          <SearchDateRange dateRange={dateRange} handleChange={searchDateRangeHandleChange} />
         </Box>
-        <Box height="50px" display="flex" justifyContent="center" alignItems="center">
-          {/* for testing... sitterId === test-sitter-1 */}
-          <Typography component={Link} to="/listings/test-sitter-1" align="center">
-            Go To TestSitter1 Profile Detail
-          </Typography>
-        </Box>
-        <Box height="50px" display="flex" justifyContent="center" alignItems="center">
-          {/* for testing... sitterId === test-sitter-2 */}
-          <Typography component={Link} to="/listings/test-sitter-2" align="center">
-            Go To TestSitter2 Profile Detail
-          </Typography>
+
+        <Grid container>
+          {sampleData.slice(0, 6).map((sitter) => {
+            console.log(sitter);
+            return <SitterCard key={sitter.sitterId} sitter={sitter} />;
+          })}
+        </Grid>
+        <Box display="flex" justifyContent="center" alignItems="center" className={classes.showMoreBox}>
+          <Button variant="outlined" onClick={handleShowMore} className={classes.showMoreBtn}>
+            Show More
+          </Button>
         </Box>
       </Grid>
     </Layout>

--- a/client/src/pages/Listings/Listings.tsx
+++ b/client/src/pages/Listings/Listings.tsx
@@ -1,6 +1,6 @@
 import { useState, ChangeEvent } from 'react';
 import Box from '@material-ui/core/Box';
-import Grid from '@material-ui/core/Grid';
+import Grid from '@mui/material/Grid';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 import { DateRange } from '@mui/lab/DateRangePicker';
@@ -30,9 +30,8 @@ const Listings = (): JSX.Element => {
   };
 
   // TODO: implement this feature later in the future
-  const handleShowMore = () => {
-    console.log('Load More clicked');
-  };
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  const handleShowMore = () => {};
 
   return (
     <Layout>
@@ -53,11 +52,10 @@ const Listings = (): JSX.Element => {
           <SearchDateRange dateRange={dateRange} handleChange={searchDateRangeHandleChange} />
         </Box>
 
-        <Grid container>
-          {sampleData.slice(0, 6).map((sitter) => {
-            console.log(sitter);
-            return <SitterCard key={sitter.sitterId} sitter={sitter} />;
-          })}
+        <Grid container className={classes.sitterLists} justifyContent="center">
+          {sampleData.slice(0, 6).map((sitter) => (
+            <SitterCard key={sitter.sitterId} sitter={sitter} />
+          ))}
         </Grid>
         <Box display="flex" justifyContent="center" alignItems="center" className={classes.showMoreBox}>
           <Button variant="outlined" onClick={handleShowMore} className={classes.showMoreBtn}>

--- a/client/src/pages/Listings/Listings.tsx
+++ b/client/src/pages/Listings/Listings.tsx
@@ -29,7 +29,6 @@ const Listings = (): JSX.Element => {
     setDateRange(newDateRange);
   };
 
-  // TODO: implement this feature later in the future
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   const handleShowMore = () => {};
 

--- a/client/src/pages/Listings/SearchDateRange/SearchDateRange.tsx
+++ b/client/src/pages/Listings/SearchDateRange/SearchDateRange.tsx
@@ -1,0 +1,50 @@
+import Box from '@material-ui/core/Box';
+import TextField from '@mui/material/TextField';
+import AdapterDateFns from '@mui/lab/AdapterDateFns';
+import LocalizationProvider from '@mui/lab/LocalizationProvider';
+import MobileDateRangePicker from '@mui/lab/MobileDateRangePicker';
+import DateRangeIcon from '@mui/icons-material/DateRange';
+import { DateRange } from '@mui/lab/DateRangePicker';
+import useStyles from './useStyles';
+
+interface Props {
+  dateRange: DateRange<Date | null>;
+  handleChange: (newDateRange: DateRange<Date>) => void;
+}
+
+const SearchDateRange = ({ dateRange, handleChange }: Props): JSX.Element => {
+  const classes = useStyles();
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <MobileDateRangePicker
+        inputFormat="dd MMM yyyy"
+        disableMaskedInput={true}
+        startText={null}
+        endText={null}
+        value={dateRange}
+        onChange={handleChange}
+        renderInput={(startProps, endProps) => (
+          <Box>
+            <TextField
+              {...startProps}
+              InputProps={{
+                startAdornment: <DateRangeIcon className={classes.dateRangeIcon} />,
+                placeholder: 'Choose Date',
+              }}
+            />
+            <TextField
+              {...endProps}
+              InputProps={{
+                startAdornment: <DateRangeIcon className={classes.dateRangeIcon} />,
+                placeholder: 'Choose Date',
+              }}
+            />
+          </Box>
+        )}
+      />
+    </LocalizationProvider>
+  );
+};
+
+export default SearchDateRange;

--- a/client/src/pages/Listings/SearchDateRange/SearchDateRange.tsx
+++ b/client/src/pages/Listings/SearchDateRange/SearchDateRange.tsx
@@ -6,6 +6,7 @@ import MobileDateRangePicker from '@mui/lab/MobileDateRangePicker';
 import DateRangeIcon from '@mui/icons-material/DateRange';
 import { DateRange } from '@mui/lab/DateRangePicker';
 import useStyles from './useStyles';
+import { Typography } from '@material-ui/core';
 
 interface Props {
   dateRange: DateRange<Date | null>;
@@ -14,6 +15,15 @@ interface Props {
 
 const SearchDateRange = ({ dateRange, handleChange }: Props): JSX.Element => {
   const classes = useStyles();
+
+  const formattedDateRangeText = (dateRange: DateRange<Date>): string => {
+    const startYear = dateRange[0]?.getFullYear();
+    const startDate = dateRange[0]?.getDate();
+    const startMonth = dateRange[0]?.toLocaleDateString('en-US', { month: 'short' });
+    const endDate = dateRange[1]?.getDate();
+    const endMonth = dateRange[1]?.toLocaleDateString('en-US', { month: 'short' });
+    return `${startDate} ${startMonth} - ${endDate} ${endMonth} ${startYear}`;
+  };
 
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns}>
@@ -25,21 +35,21 @@ const SearchDateRange = ({ dateRange, handleChange }: Props): JSX.Element => {
         value={dateRange}
         onChange={handleChange}
         renderInput={(startProps, endProps) => (
-          <Box>
+          <Box className={classes.dateRangeBox}>
+            {!startProps.focused && !dateRange[0] && (
+              <Typography className={classes.fakePlaceholder}>Choose Dates</Typography>
+            )}
             <TextField
               {...startProps}
               InputProps={{
                 startAdornment: <DateRangeIcon className={classes.dateRangeIcon} />,
-                placeholder: 'Choose Date',
+                className: classes.startDateField,
               }}
             />
-            <TextField
-              {...endProps}
-              InputProps={{
-                startAdornment: <DateRangeIcon className={classes.dateRangeIcon} />,
-                placeholder: 'Choose Date',
-              }}
-            />
+            {dateRange[0] !== null && dateRange[1] !== null && (
+              <Typography className={classes.formattedDateRangeText}>{formattedDateRangeText(dateRange)}</Typography>
+            )}
+            <TextField {...endProps} className={classes.endDateField} />
           </Box>
         )}
       />

--- a/client/src/pages/Listings/SearchDateRange/useStyles.ts
+++ b/client/src/pages/Listings/SearchDateRange/useStyles.ts
@@ -1,0 +1,10 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+  dateRangeIcon: {
+    color: '#aaa',
+    marginRight: theme.spacing(1),
+  },
+}));
+
+export default useStyles;

--- a/client/src/pages/Listings/SearchDateRange/useStyles.ts
+++ b/client/src/pages/Listings/SearchDateRange/useStyles.ts
@@ -1,9 +1,36 @@
 import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme) => ({
+  dateRangeBox: {
+    position: 'relative',
+  },
   dateRangeIcon: {
     color: '#aaa',
     marginRight: theme.spacing(1),
+  },
+  fakePlaceholder: {
+    position: 'absolute',
+    top: '18px',
+    left: '48px',
+    font: 'inherit',
+    fontSize: '14px',
+    color: '#aaa',
+    fontWeight: 700,
+  },
+  formattedDateRangeText: {
+    position: 'absolute',
+    top: '18px',
+    left: '48px',
+  },
+  startDateField: {
+    color: 'transparent !important',
+    backgroundColor: 'transparent',
+    [theme.breakpoints.down('xs')]: {
+      width: '80vw',
+    },
+  },
+  endDateField: {
+    display: 'none !important',
   },
 }));
 

--- a/client/src/pages/Listings/SearchLocation/SearchLocation.tsx
+++ b/client/src/pages/Listings/SearchLocation/SearchLocation.tsx
@@ -1,19 +1,22 @@
-import { ChangeEvent, useState, SyntheticEvent } from 'react';
+import { useState, SyntheticEvent } from 'react';
+import { Box, InputBase, Autocomplete } from '@mui/material';
 import SearchIcon from '@material-ui/icons/Search';
-import InputBase from '@material-ui/core/InputBase';
-import Autocomplete from '@material-ui/lab/Autocomplete';
-import { Sitter } from '../../Profile/ProfileDetail/sampleData';
+import { Sitter, sampleData } from '../../Profile/ProfileDetail/sampleData';
 import useStyles from './useStyles';
 
 interface Props {
   search: string;
-  handleChange: (event: ChangeEvent<HTMLInputElement>, newInputValue: string) => void;
+  handleChange: (event: SyntheticEvent<Element, Event>, newInputValue: string) => void;
 }
 
 const SearchLocation = ({ search, handleChange }: Props): JSX.Element => {
   const classes = useStyles();
   const [open, setOpen] = useState(false);
-  const [options, setOptions] = useState<Sitter[]>([]);
+  // this will be used when implementing search functionality
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [options, setOptions] = useState<Sitter[]>(sampleData);
+  // this will be used when implementing search functionality
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [loading, setLoading] = useState(false);
 
   return (
@@ -31,36 +34,26 @@ const SearchLocation = ({ search, handleChange }: Props): JSX.Element => {
         onClose={() => {
           setOpen(false);
         }}
-        getOptionSelected={(option, value) => option.sitterCity === value.sitterCity}
         getOptionLabel={(option) => option.sitterCity}
         options={options}
         loading={loading}
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
         onInputChange={handleChange}
         inputValue={search}
         noOptionsText="No Sitters Found"
         freeSolo
         renderInput={(params) => (
-          <div className={classes.search}>
+          <Box width="300px" height="56px" className={classes.search}>
             <InputBase
-              {...params.inputProps}
+              ref={params.InputProps.ref}
+              inputProps={params.inputProps}
               placeholder="Search"
               classes={{
                 root: classes.searchRoot,
                 input: classes.searchInput,
               }}
-              inputProps={{
-                'aria-label': 'search',
-                ref: params.InputProps.ref,
-              }}
-              startAdornment={
-                <div className={classes.searchIcon}>
-                  <SearchIcon />
-                </div>
-              }
+              startAdornment={<SearchIcon className={classes.searchIcon} />}
             />
-          </div>
+          </Box>
         )}
       />
     </form>

--- a/client/src/pages/Listings/SearchLocation/SearchLocation.tsx
+++ b/client/src/pages/Listings/SearchLocation/SearchLocation.tsx
@@ -1,0 +1,70 @@
+import { ChangeEvent, useState, SyntheticEvent } from 'react';
+import SearchIcon from '@material-ui/icons/Search';
+import InputBase from '@material-ui/core/InputBase';
+import Autocomplete from '@material-ui/lab/Autocomplete';
+import { Sitter } from '../../Profile/ProfileDetail/sampleData';
+import useStyles from './useStyles';
+
+interface Props {
+  search: string;
+  handleChange: (event: ChangeEvent<HTMLInputElement>, newInputValue: string) => void;
+}
+
+const SearchLocation = ({ search, handleChange }: Props): JSX.Element => {
+  const classes = useStyles();
+  const [open, setOpen] = useState(false);
+  const [options, setOptions] = useState<Sitter[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  return (
+    <form
+      onSubmit={(e: SyntheticEvent) => {
+        e.preventDefault();
+      }}
+    >
+      <Autocomplete
+        id="asynchronous-search-location"
+        open={open}
+        onOpen={() => {
+          setOpen(true);
+        }}
+        onClose={() => {
+          setOpen(false);
+        }}
+        getOptionSelected={(option, value) => option.sitterCity === value.sitterCity}
+        getOptionLabel={(option) => option.sitterCity}
+        options={options}
+        loading={loading}
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        onInputChange={handleChange}
+        inputValue={search}
+        noOptionsText="No Sitters Found"
+        freeSolo
+        renderInput={(params) => (
+          <div className={classes.search}>
+            <InputBase
+              {...params.inputProps}
+              placeholder="Search"
+              classes={{
+                root: classes.searchRoot,
+                input: classes.searchInput,
+              }}
+              inputProps={{
+                'aria-label': 'search',
+                ref: params.InputProps.ref,
+              }}
+              startAdornment={
+                <div className={classes.searchIcon}>
+                  <SearchIcon />
+                </div>
+              }
+            />
+          </div>
+        )}
+      />
+    </form>
+  );
+};
+
+export default SearchLocation;

--- a/client/src/pages/Listings/SearchLocation/useStyles.ts
+++ b/client/src/pages/Listings/SearchLocation/useStyles.ts
@@ -5,34 +5,23 @@ const useStyles = makeStyles((theme) => ({
     position: 'relative',
     borderRadius: theme.shape.borderRadius,
     marginLeft: 0,
-    height: '56px',
     lineHeight: '18px',
-    width: '300px',
     border: '1px solid #ccc',
     [theme.breakpoints.down('xs')]: {
-      width: '80vw',
+      width: '80vw !important',
     },
   },
   searchRoot: {
-    color: 'inherit',
     width: '100%',
     height: '100%',
   },
   searchInput: {
-    padding: theme.spacing(1, 1, 1, 0),
-    paddingLeft: `calc(1em + ${theme.spacing(4)}px)`,
-    width: '100%',
-    fontWeight: 600,
+    paddingLeft: '48px !important',
   },
   searchIcon: {
-    color: '#f04040',
-    height: '100%',
     position: 'absolute',
     pointerEvents: 'none',
     marginLeft: '1rem',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
   },
 }));
 

--- a/client/src/pages/Listings/SearchLocation/useStyles.ts
+++ b/client/src/pages/Listings/SearchLocation/useStyles.ts
@@ -9,6 +9,9 @@ const useStyles = makeStyles((theme) => ({
     lineHeight: '18px',
     width: '300px',
     border: '1px solid #ccc',
+    [theme.breakpoints.down('xs')]: {
+      width: '80vw',
+    },
   },
   searchRoot: {
     color: 'inherit',

--- a/client/src/pages/Listings/SearchLocation/useStyles.ts
+++ b/client/src/pages/Listings/SearchLocation/useStyles.ts
@@ -1,0 +1,36 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+  search: {
+    position: 'relative',
+    borderRadius: theme.shape.borderRadius,
+    marginLeft: 0,
+    height: '56px',
+    lineHeight: '18px',
+    width: '300px',
+    border: '1px solid #ccc',
+  },
+  searchRoot: {
+    color: 'inherit',
+    width: '100%',
+    height: '100%',
+  },
+  searchInput: {
+    padding: theme.spacing(1, 1, 1, 0),
+    paddingLeft: `calc(1em + ${theme.spacing(4)}px)`,
+    width: '100%',
+    fontWeight: 600,
+  },
+  searchIcon: {
+    color: '#f04040',
+    height: '100%',
+    position: 'absolute',
+    pointerEvents: 'none',
+    marginLeft: '1rem',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+}));
+
+export default useStyles;

--- a/client/src/pages/Listings/SitterCard/SitterCard.tsx
+++ b/client/src/pages/Listings/SitterCard/SitterCard.tsx
@@ -1,11 +1,5 @@
-import Box from '@material-ui/core/Box';
-import Grid from '@material-ui/core/Grid';
-import Paper from '@material-ui/core/Paper';
-import Avatar from '@material-ui/core/Avatar';
-import Rating from '@mui/material/Rating';
+import { Grid, Box, Card, CardContent, Avatar, Rating, Typography } from '@mui/material';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
-
-import Typography from '@material-ui/core/Typography';
 import useStyles from './useStyles';
 import { Sitter } from '../../Profile/ProfileDetail/sampleData';
 import { Link } from 'react-router-dom';
@@ -18,22 +12,16 @@ const SitterCard = ({ sitter }: Props): JSX.Element => {
   const classes = useStyles();
 
   return (
-    <Grid item xs={12} sm={5} md={4}>
-      <Box
-        width="80%"
-        display="flex"
-        justifyContent="space-evenly"
-        alignItems="center"
-        className={classes.sitterOuterBox}
-      >
-        <Paper elevation={6}>
-          <Box
-            height="320px"
+    <Grid item xs={12} sm={5} md={4} className={classes.root}>
+      <Box width="80%" display="flex" justifyContent="center" alignItems="center" className={classes.sitterOuterBox}>
+        <Card raised>
+          <CardContent
+            component={Box}
+            height="100%"
             display="flex"
             flexDirection="column"
             justifyContent="center"
             alignItems="center"
-            className={classes.sitterBox}
           >
             <Avatar
               variant="circular"
@@ -43,10 +31,10 @@ const SitterCard = ({ sitter }: Props): JSX.Element => {
               component={Link}
               to={`/listings/${sitter.sitterId}`}
             />
-            <Typography component="h5" variant="h5" align="center" className={classes.sitterName}>
+            <Typography component="h5" variant="h5" className={classes.sitterName}>
               {`${sitter.sitterFirstName} ${sitter.sitterLastName}`}
             </Typography>
-            <Typography component="h6" variant="h6" align="center" className={classes.sitterShortDesc}>
+            <Typography variant="body2" className={classes.sitterShortDesc}>
               {sitter.sitterShortDesc}
             </Typography>
             <Rating name="read-only" size="small" value={sitter.sitterRating} readOnly className={classes.rating} />
@@ -62,7 +50,7 @@ const SitterCard = ({ sitter }: Props): JSX.Element => {
             >
               <Box display="flex" alignItems="center">
                 <LocationOnIcon className={classes.locationIcon} />
-                <Typography variant="body2" className={classes.locationText}>
+                <Typography variant="body2" sx={{ ml: 0.5 }} className={classes.locationText}>
                   {`${sitter.sitterCity}, ${sitter.sitterProvince}`}
                 </Typography>
               </Box>
@@ -70,8 +58,8 @@ const SitterCard = ({ sitter }: Props): JSX.Element => {
                 ${sitter.sitterWage}/hr
               </Typography>
             </Box>
-          </Box>
-        </Paper>
+          </CardContent>
+        </Card>
       </Box>
     </Grid>
   );

--- a/client/src/pages/Listings/SitterCard/SitterCard.tsx
+++ b/client/src/pages/Listings/SitterCard/SitterCard.tsx
@@ -1,0 +1,80 @@
+import Box from '@material-ui/core/Box';
+import Grid from '@material-ui/core/Grid';
+import Paper from '@material-ui/core/Paper';
+import Avatar from '@material-ui/core/Avatar';
+import Rating from '@mui/material/Rating';
+import LocationOnIcon from '@mui/icons-material/LocationOn';
+
+import Typography from '@material-ui/core/Typography';
+import useStyles from './useStyles';
+import { Sitter } from '../../Profile/ProfileDetail/sampleData';
+import { Link } from 'react-router-dom';
+
+interface Props {
+  sitter: Sitter;
+}
+
+const SitterCard = ({ sitter }: Props): JSX.Element => {
+  const classes = useStyles();
+
+  return (
+    <Grid item xs={12} sm={12} md={4} className={classes.sitterCard}>
+      <Box
+        width="80%"
+        display="flex"
+        justifyContent="space-evenly"
+        alignItems="center"
+        className={classes.sitterOuterBox}
+      >
+        <Paper elevation={6}>
+          <Box
+            height="320px"
+            display="flex"
+            flexDirection="column"
+            justifyContent="center"
+            alignItems="center"
+            className={classes.sitterBox}
+          >
+            <Avatar
+              variant="circular"
+              className={classes.avatar}
+              src={sitter.userProfileImage}
+              alt={`${sitter.sitterFirstName}-${sitter.sitterLastName}-profile-image`}
+              component={Link}
+              to={`/listings/${sitter.sitterId}`}
+            />
+            <Typography component="h5" variant="h5" align="center" className={classes.sitterName}>
+              {`${sitter.sitterFirstName} ${sitter.sitterLastName}`}
+            </Typography>
+            <Typography component="h6" variant="h6" align="center" className={classes.sitterShortDesc}>
+              {sitter.sitterShortDesc}
+            </Typography>
+            <Rating name="read-only" size="small" value={sitter.sitterRating} readOnly className={classes.rating} />
+            <Typography variant="body1" align="center" className={classes.sitterAboutMe}>
+              {sitter.sitterAboutMe.slice(0, 80)}
+            </Typography>
+            <Box
+              width="95%"
+              display="flex"
+              justifyContent="space-between"
+              alignItems="center"
+              className={classes.locationWage}
+            >
+              <Box display="flex" alignItems="center">
+                <LocationOnIcon className={classes.locationIcon} />
+                <Typography variant="body2" className={classes.locationText}>
+                  {`${sitter.sitterCity}, ${sitter.sitterProvince}`}
+                </Typography>
+              </Box>
+              <Typography component="h6" variant="h6" align="center" className={classes.wage}>
+                ${sitter.sitterWage}/hr
+              </Typography>
+            </Box>
+          </Box>
+        </Paper>
+      </Box>
+    </Grid>
+  );
+};
+
+export default SitterCard;

--- a/client/src/pages/Listings/SitterCard/SitterCard.tsx
+++ b/client/src/pages/Listings/SitterCard/SitterCard.tsx
@@ -18,7 +18,7 @@ const SitterCard = ({ sitter }: Props): JSX.Element => {
   const classes = useStyles();
 
   return (
-    <Grid item xs={12} sm={12} md={4} className={classes.sitterCard}>
+    <Grid item xs={12} sm={5} md={4}>
       <Box
         width="80%"
         display="flex"
@@ -51,7 +51,7 @@ const SitterCard = ({ sitter }: Props): JSX.Element => {
             </Typography>
             <Rating name="read-only" size="small" value={sitter.sitterRating} readOnly className={classes.rating} />
             <Typography variant="body1" align="center" className={classes.sitterAboutMe}>
-              {sitter.sitterAboutMe.slice(0, 80)}
+              {sitter.sitterAboutMe.slice(0, 60)}
             </Typography>
             <Box
               width="95%"

--- a/client/src/pages/Listings/SitterCard/useStyles.ts
+++ b/client/src/pages/Listings/SitterCard/useStyles.ts
@@ -1,0 +1,63 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+  sitterCard: {},
+  sitterOuterBox: {
+    margin: theme.spacing(3, 'auto'),
+  },
+  sitterBox: {
+    margin: theme.spacing(2, 0, 0),
+  },
+  avatar: {
+    width: '100px',
+    height: '100px',
+    border: '5px solid #ffffff',
+    '&:hover': {
+      opacity: '0.8',
+    },
+  },
+  sitterName: {
+    padding: theme.spacing(1),
+    fontWeight: 700,
+  },
+  sitterShortDesc: {
+    color: '#aaa',
+    fontSize: '12px',
+    fontWeight: 700,
+  },
+  sitterAboutMe: {
+    padding: theme.spacing(0, 2),
+  },
+  sitterLocation: {},
+  sitterLocationText: {
+    color: '#aaa',
+    fontSize: '14px',
+    fontWeight: 700,
+  },
+  profileDetailBottom: {
+    padding: theme.spacing(2, 4),
+  },
+  aboutMeDesc: {
+    marginBottom: theme.spacing(3),
+  },
+  rating: {
+    margin: theme.spacing(1, 'auto'),
+  },
+  locationIcon: {
+    color: theme.palette.primary.main,
+  },
+  locationWage: {
+    borderTop: '1px solid #ccc',
+    padding: theme.spacing(1, 2, 0),
+    margin: theme.spacing(2),
+  },
+  locationText: {
+    color: '#aaa',
+    fontSize: '13px',
+  },
+  wage: {
+    fontWeight: 700,
+  },
+}));
+
+export default useStyles;

--- a/client/src/pages/Listings/SitterCard/useStyles.ts
+++ b/client/src/pages/Listings/SitterCard/useStyles.ts
@@ -1,7 +1,6 @@
 import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme) => ({
-  sitterCard: {},
   sitterOuterBox: {
     margin: theme.spacing(3, 'auto'),
   },

--- a/client/src/pages/Listings/SitterCard/useStyles.ts
+++ b/client/src/pages/Listings/SitterCard/useStyles.ts
@@ -1,15 +1,20 @@
 import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme) => ({
+  root: {
+    '& .MuiCardContent-root:last-child': {
+      paddingBottom: theme.spacing(1.5),
+    },
+  },
   sitterOuterBox: {
     margin: theme.spacing(3, 'auto'),
-  },
-  sitterBox: {
-    margin: theme.spacing(2, 0, 0),
+    [theme.breakpoints.down('xs')]: {
+      width: '70% !important',
+    },
   },
   avatar: {
-    width: '100px',
-    height: '100px',
+    width: '100px !important',
+    height: '100px !important',
     border: '5px solid #ffffff',
     '&:hover': {
       opacity: '0.8',
@@ -17,21 +22,12 @@ const useStyles = makeStyles((theme) => ({
   },
   sitterName: {
     padding: theme.spacing(1),
-    fontWeight: 700,
   },
   sitterShortDesc: {
     color: '#aaa',
-    fontSize: '12px',
-    fontWeight: 700,
   },
   sitterAboutMe: {
     padding: theme.spacing(0, 2),
-  },
-  sitterLocation: {},
-  sitterLocationText: {
-    color: '#aaa',
-    fontSize: '14px',
-    fontWeight: 700,
   },
   profileDetailBottom: {
     padding: theme.spacing(2, 4),
@@ -47,12 +43,11 @@ const useStyles = makeStyles((theme) => ({
   },
   locationWage: {
     borderTop: '1px solid #ccc',
-    padding: theme.spacing(1, 2, 0),
-    margin: theme.spacing(2),
+    padding: theme.spacing(1, 0, 0),
+    margin: theme.spacing(2, 0, 0),
   },
   locationText: {
     color: '#aaa',
-    fontSize: '13px',
   },
   wage: {
     fontWeight: 700,

--- a/client/src/pages/Listings/useStyles.ts
+++ b/client/src/pages/Listings/useStyles.ts
@@ -11,14 +11,20 @@ const useStyles = makeStyles((theme) => ({
     fontWeight: 700,
   },
   searchBox: {
-    margin: theme.spacing(4, 0),
+    margin: theme.spacing(2, 0),
+    [theme.breakpoints.down('xs')]: {
+      flexDirection: 'column',
+    },
   },
   dateRangeIcon: {
     color: '#aaa',
     marginRight: theme.spacing(1),
   },
+  sitterLists: {
+    maxWidth: '1280px',
+  },
   showMoreBox: {
-    margin: theme.spacing(5, 'auto'),
+    margin: theme.spacing(1, 'auto', 4),
   },
   showMoreBtn: {
     width: '150px',

--- a/client/src/pages/Listings/useStyles.ts
+++ b/client/src/pages/Listings/useStyles.ts
@@ -1,7 +1,30 @@
 import { makeStyles } from '@material-ui/core/styles';
 
-const useStyles = makeStyles(() => ({
-  // TODO: this useStyles will be used in the future
+const useStyles = makeStyles((theme) => ({
+  listings: {
+    backgroundColor: '#ffffff',
+  },
+  searchTitleBox: {
+    margin: theme.spacing(2, 0),
+  },
+  searchTitleText: {
+    fontWeight: 700,
+  },
+  searchBox: {
+    margin: theme.spacing(4, 0),
+  },
+  dateRangeIcon: {
+    color: '#aaa',
+    marginRight: theme.spacing(1),
+  },
+  showMoreBox: {
+    margin: theme.spacing(5, 'auto'),
+  },
+  showMoreBtn: {
+    width: '150px',
+    textTransform: 'uppercase',
+    padding: theme.spacing(1),
+  },
 }));
 
 export default useStyles;

--- a/client/src/pages/MyJobs/MyJobs.tsx
+++ b/client/src/pages/MyJobs/MyJobs.tsx
@@ -5,7 +5,6 @@ import Layout from '../Layout/Layout';
 import useStyles from './useStyles';
 
 const MyJobs = (): JSX.Element => {
-  // TODO: this will be used in the future
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const classes = useStyles();
 

--- a/client/src/pages/MyJobs/useStyles.ts
+++ b/client/src/pages/MyJobs/useStyles.ts
@@ -1,7 +1,5 @@
 import { makeStyles } from '@material-ui/core/styles';
 
-const useStyles = makeStyles(() => ({
-  // TODO: this useStyles will be used in the future
-}));
+const useStyles = makeStyles(() => ({}));
 
 export default useStyles;

--- a/client/src/pages/MySitters/MySitters.tsx
+++ b/client/src/pages/MySitters/MySitters.tsx
@@ -5,7 +5,6 @@ import Layout from '../Layout/Layout';
 import useStyles from './useStyles';
 
 const MySitters = (): JSX.Element => {
-  // TODO: this will be used in the future
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const classes = useStyles();
 

--- a/client/src/pages/MySitters/useStyles.ts
+++ b/client/src/pages/MySitters/useStyles.ts
@@ -1,7 +1,5 @@
 import { makeStyles } from '@material-ui/core/styles';
 
-const useStyles = makeStyles(() => ({
-  // TODO: this useStyles will be used in the future
-}));
+const useStyles = makeStyles(() => ({}));
 
 export default useStyles;

--- a/client/src/pages/Profile/Profile.tsx
+++ b/client/src/pages/Profile/Profile.tsx
@@ -5,7 +5,6 @@ import Layout from '../Layout/Layout';
 import useStyles from './useStyles';
 
 const Profile = (): JSX.Element => {
-  // TODO: this will be used in the future
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const classes = useStyles();
 

--- a/client/src/pages/Profile/ProfileDetail/ProfileDetail.tsx
+++ b/client/src/pages/Profile/ProfileDetail/ProfileDetail.tsx
@@ -10,10 +10,8 @@ import CircularProgress from '@material-ui/core/CircularProgress';
 import ProfileDetailCard from './ProfileDetailCard/ProfileDetailCard';
 import BookingCard from './BookingCard/BookingCard';
 import { Sitter } from './sampleData';
-import useStyles from './useStyles';
 
 const ProfileDetail = (): JSX.Element => {
-  const classes = useStyles();
   const params: { sitterId: string } = useParams();
   const { sitterId } = params;
 
@@ -36,7 +34,7 @@ const ProfileDetail = (): JSX.Element => {
 
   return (
     <Layout>
-      <Box width="100%" className={classes.outerContainer}>
+      <Box width="100%">
         <Grid
           maxWidth="2160px"
           container

--- a/client/src/pages/Profile/ProfileDetail/ProfileDetailCard/useStyles.ts
+++ b/client/src/pages/Profile/ProfileDetail/ProfileDetailCard/useStyles.ts
@@ -27,6 +27,7 @@ const useStyles = makeStyles((theme) => ({
     top: '120px',
     left: '50%',
     marginLeft: '-75px',
+    backgroundColor: '#eee',
   },
   sitterName: {
     padding: theme.spacing(10, 0, 1),

--- a/client/src/pages/Profile/ProfileDetail/sampleData.ts
+++ b/client/src/pages/Profile/ProfileDetail/sampleData.ts
@@ -22,7 +22,7 @@ export const sampleData: Sitter[] = [
   {
     sitterId: 'test-sitter-1',
     profileBackgroundImg: 'https://source.unsplash.com/600x200/?nature,sky',
-    userProfileImage: 'https://source.unsplash.com/150x150/?man',
+    userProfileImage: 'https://robohash.org/test-sitter-1.png',
     sitterFirstName: 'John',
     sitterLastName: 'Doe',
     sitterShortDesc: 'Loving pet sitter',
@@ -50,7 +50,7 @@ export const sampleData: Sitter[] = [
   {
     sitterId: 'test-sitter-2',
     profileBackgroundImg: 'https://source.unsplash.com/600x200/?nature,sea',
-    userProfileImage: 'https://source.unsplash.com/150x150/?woman',
+    userProfileImage: 'https://robohash.org/test-sitter-2.png',
     sitterFirstName: 'Jane',
     sitterLastName: 'Doe',
     sitterShortDesc: 'Loving pet sitter2',
@@ -74,5 +74,173 @@ export const sampleData: Sitter[] = [
     ],
     sitterWage: 16,
     sitterRating: 5,
+  },
+  {
+    sitterId: 'test-sitter-3',
+    profileBackgroundImg: 'https://source.unsplash.com/600x200/?nature,sky',
+    userProfileImage: 'https://robohash.org/test-sitter-3.png',
+    sitterFirstName: 'Fname3 ',
+    sitterLastName: 'Lname3',
+    sitterShortDesc: 'Loving pet sitter3',
+    sitterCity: 'Ottawa',
+    sitterProvince: 'Ontario',
+    sitterAboutMe:
+      'Animals are my passion! I will look after your pets with loving care. I have some availability for pet care in my home as well. I have 10 yrs experience at the Animal Hospital, and have owned multiple pets for many years, including numerous rescues. Kindly email, text or call me and I will respond promptly!',
+    sitterPetImages: [
+      {
+        img: 'https://source.unsplash.com/125x125/?animal,puppy',
+        title: 'puppy',
+      },
+      {
+        img: 'https://source.unsplash.com/125x125/?animal,cat',
+        title: 'cat',
+      },
+      {
+        img: 'https://source.unsplash.com/125x125/?animal,dog',
+        title: 'dog',
+      },
+    ],
+    sitterWage: 13,
+    sitterRating: 4,
+  },
+  {
+    sitterId: 'test-sitter-4',
+    profileBackgroundImg: 'https://source.unsplash.com/600x200/?nature,sky',
+    userProfileImage: 'https://robohash.org/test-sitter-4.png',
+    sitterFirstName: 'Fname4 ',
+    sitterLastName: 'Lname4',
+    sitterShortDesc: 'Loving pet sitter4',
+    sitterCity: 'Toronto',
+    sitterProvince: 'Ontario',
+    sitterAboutMe:
+      'Animals are my passion! I will look after your pets with loving care. I have some availability for pet care in my home as well. I have 10 yrs experience at the Animal Hospital, and have owned multiple pets for many years, including numerous rescues. Kindly email, text or call me and I will respond promptly!',
+    sitterPetImages: [
+      {
+        img: 'https://source.unsplash.com/125x125/?animal,puppy',
+        title: 'puppy',
+      },
+      {
+        img: 'https://source.unsplash.com/125x125/?animal,cat',
+        title: 'cat',
+      },
+      {
+        img: 'https://source.unsplash.com/125x125/?animal,dog',
+        title: 'dog',
+      },
+    ],
+    sitterWage: 14,
+    sitterRating: 4,
+  },
+  {
+    sitterId: 'test-sitter-5',
+    profileBackgroundImg: 'https://source.unsplash.com/600x200/?nature,sky',
+    userProfileImage: 'https://robohash.org/test-sitter-5.png',
+    sitterFirstName: 'Fname5 ',
+    sitterLastName: 'Lname5',
+    sitterShortDesc: 'Loving pet sitter5',
+    sitterCity: 'Toronto',
+    sitterProvince: 'Ontario',
+    sitterAboutMe:
+      'Animals are my passion! I will look after your pets with loving care. I have some availability for pet care in my home as well. I have 10 yrs experience at the Animal Hospital, and have owned multiple pets for many years, including numerous rescues. Kindly email, text or call me and I will respond promptly!',
+    sitterPetImages: [
+      {
+        img: 'https://source.unsplash.com/125x125/?animal,puppy',
+        title: 'puppy',
+      },
+      {
+        img: 'https://source.unsplash.com/125x125/?animal,cat',
+        title: 'cat',
+      },
+      {
+        img: 'https://source.unsplash.com/125x125/?animal,dog',
+        title: 'dog',
+      },
+    ],
+    sitterWage: 15,
+    sitterRating: 3,
+  },
+  {
+    sitterId: 'test-sitter-6',
+    profileBackgroundImg: 'https://source.unsplash.com/600x200/?nature,sky',
+    userProfileImage: 'https://robohash.org/test-sitter-6.png',
+    sitterFirstName: 'Fname6 ',
+    sitterLastName: 'Lname6',
+    sitterShortDesc: 'Loving pet sitter6',
+    sitterCity: 'Toronto',
+    sitterProvince: 'Ontario',
+    sitterAboutMe:
+      'Animals are my passion! I will look after your pets with loving care. I have some availability for pet care in my home as well. I have 10 yrs experience at the Animal Hospital, and have owned multiple pets for many years, including numerous rescues. Kindly email, text or call me and I will respond promptly!',
+    sitterPetImages: [
+      {
+        img: 'https://source.unsplash.com/125x125/?animal,puppy',
+        title: 'puppy',
+      },
+      {
+        img: 'https://source.unsplash.com/125x125/?animal,cat',
+        title: 'cat',
+      },
+      {
+        img: 'https://source.unsplash.com/125x125/?animal,dog',
+        title: 'dog',
+      },
+    ],
+    sitterWage: 16,
+    sitterRating: 2,
+  },
+  {
+    sitterId: 'test-sitter-7',
+    profileBackgroundImg: 'https://source.unsplash.com/600x200/?nature,sky',
+    userProfileImage: 'https://robohash.org/test-sitter-7.png',
+    sitterFirstName: 'Fname7 ',
+    sitterLastName: 'Lname7',
+    sitterShortDesc: 'Loving pet sitter7',
+    sitterCity: 'Toronto',
+    sitterProvince: 'Ontario',
+    sitterAboutMe:
+      'Animals are my passion! I will look after your pets with loving care. I have some availability for pet care in my home as well. I have 10 yrs experience at the Animal Hospital, and have owned multiple pets for many years, including numerous rescues. Kindly email, text or call me and I will respond promptly!',
+    sitterPetImages: [
+      {
+        img: 'https://source.unsplash.com/125x125/?animal,puppy',
+        title: 'puppy',
+      },
+      {
+        img: 'https://source.unsplash.com/125x125/?animal,cat',
+        title: 'cat',
+      },
+      {
+        img: 'https://source.unsplash.com/125x125/?animal,dog',
+        title: 'dog',
+      },
+    ],
+    sitterWage: 17,
+    sitterRating: 1,
+  },
+  {
+    sitterId: 'test-sitter-8',
+    profileBackgroundImg: 'https://source.unsplash.com/600x200/?nature,sky',
+    userProfileImage: 'https://robohash.org/test-sitter-8.png',
+    sitterFirstName: 'Fname8 ',
+    sitterLastName: 'Lname8',
+    sitterShortDesc: 'Loving pet sitter8',
+    sitterCity: 'Toronto',
+    sitterProvince: 'Ontario',
+    sitterAboutMe:
+      'Animals are my passion! I will look after your pets with loving care. I have some availability for pet care in my home as well. I have 10 yrs experience at the Animal Hospital, and have owned multiple pets for many years, including numerous rescues. Kindly email, text or call me and I will respond promptly!',
+    sitterPetImages: [
+      {
+        img: 'https://source.unsplash.com/125x125/?animal,puppy',
+        title: 'puppy',
+      },
+      {
+        img: 'https://source.unsplash.com/125x125/?animal,cat',
+        title: 'cat',
+      },
+      {
+        img: 'https://source.unsplash.com/125x125/?animal,dog',
+        title: 'dog',
+      },
+    ],
+    sitterWage: 18,
+    sitterRating: 4,
   },
 ];

--- a/client/src/pages/Profile/ProfileDetail/useStyles.ts
+++ b/client/src/pages/Profile/ProfileDetail/useStyles.ts
@@ -1,9 +1,0 @@
-import { makeStyles } from '@material-ui/core/styles';
-
-const useStyles = makeStyles(() => ({
-  outerContainer: {
-    backgroundColor: '#eee',
-  },
-}));
-
-export default useStyles;

--- a/client/src/pages/Profile/useStyles.ts
+++ b/client/src/pages/Profile/useStyles.ts
@@ -1,7 +1,5 @@
 import { makeStyles } from '@material-ui/core/styles';
 
-const useStyles = makeStyles(() => ({
-  // TODO: this useStyles will be used in the future
-}));
+const useStyles = makeStyles(() => ({}));
 
 export default useStyles;

--- a/client/src/pages/TempDashboardMain/TempDashboardMain.tsx
+++ b/client/src/pages/TempDashboardMain/TempDashboardMain.tsx
@@ -5,7 +5,6 @@ import Layout from '../Layout/Layout';
 import useStyles from './useStyles';
 
 const TempDashboardMain = (): JSX.Element => {
-  // TODO: this will be used in the future
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const classes = useStyles();
 

--- a/client/src/pages/TempDashboardMain/useStyles.ts
+++ b/client/src/pages/TempDashboardMain/useStyles.ts
@@ -1,7 +1,5 @@
 import { makeStyles } from '@material-ui/core/styles';
 
-const useStyles = makeStyles(() => ({
-  // TODO: this useStyles will be used in the future
-}));
+const useStyles = makeStyles(() => ({}));
 
 export default useStyles;


### PR DESCRIPTION
### What this PR does (required):
- Issue Link: https://github.com/hatchways/team-breadsticks/issues/41
- List all the profiles on the platform
- Created some mock-users(hardcoded) to display them in the listing page 

### Screenshots / Videos (required):
#### Desktop version (After logging in and clicking `BECOME A SITTER` in the navbar, URL:`localhost:3000/listings`)
![Screen Shot 2021-09-23 at 16 27 32](https://user-images.githubusercontent.com/54833010/134596789-0d368635-b3b1-45d8-904b-147aa661284a.png)
---

#### Desktop version (After clicking an avatar image in listings (e.g., click `John Doe` in the above screenshot ), URL:`localhost:3000/listings/test-sitter-1`)
![Screen Shot 2021-09-23 at 16 29 33](https://user-images.githubusercontent.com/54833010/134596907-201b8ed0-1e66-4f2f-9bb4-6c77656d74b3.png)
---

#### Tablet version (After logging in and clicking `BECOME A SITTER` in the navbar, URL:`localhost:3000/listings`)
![Screen Shot 2021-09-23 at 16 32 50](https://user-images.githubusercontent.com/54833010/134597096-01fc93e6-907c-4470-80d3-a2671919fba8.png)
---

#### Mobile version (After logging in and clicking `BECOME A SITTER` in the navbar, URL:`localhost:3000/listings`)
![Screen Shot 2021-09-23 at 16 34 10](https://user-images.githubusercontent.com/54833010/134597166-6f255a25-440f-42cc-b44f-95e7eda90775.png)
---

### Any information needed to test this feature (required):
- N/A

### Any issues with the current functionality (optional):
- In order to access ```localhost:3000/listings``` or ```localhost:3000/listings/:sitterId```, you need to **log in**
- Even if you are authenticated, you can't access ```Listings```, ```ProfileDetail```, if you manually enter these URL on browsers.
- Only way to access ```Listings```, ```ProfileDetail``` is to click link buttons on the app.
- I think this issue might be fixed after we complete https://github.com/hatchways/team-breadsticks/issues/48 .
